### PR TITLE
added docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+
+services: 
+
+  web:
+    image: haciendo_web
+    environment:
+     - API_SERVER=http://api:5000
+    ports:
+      - 15080:80
+       
+  api:
+    image: haciendo_api
+    environment:
+     - SMS_SERVER=http://sms:5001
+     - YANDEX_KEY=${YANDEX_KEY}
+    ports:
+      - 15000:5000
+
+  sms:
+    image: haciendo_sms
+    environment:
+     - TROPO_USER=${TROPO_USER}
+     - TROPO_PASS=${TROPO_PASS}
+     - TROPO_URL=http://75b0a0d3.ngrok.io  # change this to your ngrok server.
+    ports: 
+      - 15001:5001
+
+  


### PR DESCRIPTION
Hank, 
I added a docker-compose file to the lab which might be easier to run for the final part in lab step 3 rather than starting all three containers again.  Might help if pressed for time.  Users would only need to change their forwarding ngrock.io server value in the docker-compose file and then run 
```
docker-compose up  
```
Then all three containers will run.  The catch here is that environment variables would need to be defined.  I don't think you need to change the lab, but just have it in the code base just for future... or so I can feel good about myself in that I contributed something 👍 